### PR TITLE
chore: ensure the package is built before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "preconstruct build",
     "test": "jest",
     "format": "prettier --write '**/*.{js,jsx,ts,less,html,md,yml}'",
-    "prerelease": "npm run build",
+    "prerelease": "yarn build",
     "release": "np"
   },
   "browserslist": "> 0.25%, not dead",


### PR DESCRIPTION
add a `prerelease` task that builds the dist code.