### PR TITLE
feat: Use a newer version of node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: borales/actions-yarn@v2.0.0
+      - uses: actions/setup-node@v2
         with:
-          cmd: install --frozen-lockfile # will run `yarn install` command
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: sanity # will check if building works & if code is formatted well
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: test # will run `yarn test` command
+          node-version: '12.x'
+      - run: yarn install --frozen-lockfile # will run `yarn install` command
+      - run: yarn sanity # will check if building works & if code is formatted well
+      - run: yarn test


### PR DESCRIPTION
The yarn action is no longer maintained, so should use setup-node
instead.

We should see the tests still pass on this PR.
