### PR TITLE
chore: fix bson version in peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ejson-shell-parser",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ejson-shell-parser",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.1.0"
@@ -32,7 +32,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "bson": "^4.2.3 || ^5.0.0"
+        "bson": "^4 || ^5"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "bson": "^4 || ^5"
+        "bson": "^4.2.3 || ^5"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "acorn": "^8.1.0"
   },
   "peerDependencies": {
-    "bson": "^4.2.3 || ^5.0.0"
+    "bson": "^4 || ^5"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "acorn": "^8.1.0"
   },
   "peerDependencies": {
-    "bson": "^4 || ^5"
+    "bson": "^4.2.3 || ^5"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",


### PR DESCRIPTION
Remove specific version for `bson` 5 in peer dependency.