### PR TITLE
chore: remove bson from devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ejson-shell-parser",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ejson-shell-parser",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.1.0"
@@ -21,7 +21,6 @@
         "@types/estree": "^0.0.41",
         "@types/jest": "^27.5.0",
         "benchmark": "^2.1.4",
-        "bson": "^4.6.3",
         "husky": ">=5",
         "jest": "^26.6.3",
         "lint-staged": ">=11",
@@ -32,7 +31,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "bson": "^4.2.3 || ^5.0.0"
+        "bson": "^4.6.3 || ^5.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3513,7 +3512,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3765,7 +3763,6 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.3.tgz",
       "integrity": "sha512-rAqP5hcUVJhXP2MCSNVsf0oM2OGU1So6A9pVRDYayvJ5+hygXHQApf87wd5NlhPM1J9RJnbqxIG/f8QTzRoQ4A==",
-      "dev": true,
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -3777,7 +3774,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6044,7 +6040,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17237,8 +17232,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "benchmark": {
       "version": "2.1.4",
@@ -17411,7 +17405,6 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.3.tgz",
       "integrity": "sha512-rAqP5hcUVJhXP2MCSNVsf0oM2OGU1So6A9pVRDYayvJ5+hygXHQApf87wd5NlhPM1J9RJnbqxIG/f8QTzRoQ4A==",
-      "dev": true,
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -17420,7 +17413,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -19162,8 +19154,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "acorn": "^8.1.0"
   },
   "peerDependencies": {
-    "bson": "^4.2.3 || ^5.0.0"
+    "bson": "^4.6.3 || ^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",
@@ -35,7 +35,6 @@
     "@types/estree": "^0.0.41",
     "@types/jest": "^27.5.0",
     "benchmark": "^2.1.4",
-    "bson": "^4.6.3",
     "husky": ">=5",
     "jest": "^26.6.3",
     "lint-staged": ">=11",


### PR DESCRIPTION
Remove `bson` from devDependencies.

Note: version 4 of `bson` in peerDependencies is updated from _4.2.3_ to _4.6.3_ ([source](https://github.com/mongodb-js/ejson-shell-parser/pull/109#discussion_r860745049))