### PR TITLE
fix: Differentiate between new Date() and Date() COMPASS-6755

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -76,11 +76,11 @@ const binaryExpression = (node: BinaryExpression): any => {
   }
 };
 
-const memberExpression = (node: CallExpression): any => {
+const memberExpression = (node: CallExpression, withNew: boolean): any => {
   switch (node.callee.type) {
     case 'Identifier': {
       // Handing <Constructor>() and new <Constructor>() cases
-      const callee = getScopeFunction(node.callee.name);
+      const callee = getScopeFunction(node.callee.name, withNew);
       const args = node.arguments.map(arg => walk(arg));
       return callee.apply(callee, args);
     }
@@ -129,8 +129,9 @@ const walk = (node: Node): any => {
     case 'ArrayExpression':
       return node.elements.map(node => walk(node));
     case 'CallExpression':
+      return memberExpression(node, false);
     case 'NewExpression':
-      return memberExpression(node);
+      return memberExpression(node, true);
     case 'ObjectExpression':
       const obj: { [key: string]: any } = {};
       node.properties.forEach(property => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -52,7 +52,7 @@ it('should accept a complex query', function() {
     Timestamp_object: Timestamp({ t: 1, i: 2 }),
     Timestamp_long: Timestamp(new Long(1, 2)),
     ISODate: ISODate("2020-01-01 12:00:00"),
-    Date: Date("2020-01-01 12:00:00")
+    Date: new Date("2020-01-01 12:00:00")
   }`)
   ).toEqual({
     RegExp: /test/gi,
@@ -337,7 +337,7 @@ describe('Function calls', function() {
       dateSpy.mockRestore();
     });
 
-    describe.each(['new Date', 'new ISODate', 'Date', 'ISODate'])(
+    describe.each(['new Date', 'new ISODate', 'ISODate'])(
       'Date allow using member methods with "%s"',
       dateFn => {
         it('should allow member expressions', function() {
@@ -427,6 +427,17 @@ describe('Function calls', function() {
         });
       }
     );
+
+    it('should return a string if you use Date() without new', function() {
+      const isoString = '1996-02-24T23:01:59.001Z';
+      const newDate = `Date('${isoString}')`;
+
+      const input = `${newDate}`;
+
+      expect(parse(input, options)).toEqual(
+        expect.stringContaining(new Date().getUTCFullYear() + '')
+      );
+    });
   });
 
   // Testing more realistic examples of using the Date object


### PR DESCRIPTION
Maybe a bit uninspired, but seems to get the job done while continuing to work the way mongosh does, at least. ie. it keeps (mimicks?) JavaScript's behaviour where `Date('1996-02-24T23:01:59.001Z')` returns a string representing today's date.