### PR TITLE
chore!: add bson v6 to peer dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        bson: [4.x, 5.x]
+        bson: [4.x, 5.x, 6.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3.1.0
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - run: yarn install --frozen-lockfile # will run `yarn install` command
       - run: yarn add bson@${{ matrix.bson }}
       - run: yarn sanity # will check if building works & if code is formatted well

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "acorn": "^8.1.0"
   },
   "peerDependencies": {
-    "bson": "^4.6.3 || ^5.0.0"
+    "bson": "^4.6.3 || ^5 || ^6"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,less,html,md,yml}": "prettier --write"
+  },
+  "engines" : {
+    "node" : ">=16"
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -29,7 +29,7 @@ it('should accept a complex query', function() {
   expect(
     parse(`{
     RegExp: /test/ig,
-    Binary: new Binary(''),
+    Binary: new Binary(),
     BinData: BinData(3, 'dGVzdAo='),
     UUID: UUID('3d37923d-ab8e-4931-9e46-93df5fd3599e'),
     Code: Code('function() {}'),
@@ -56,7 +56,7 @@ it('should accept a complex query', function() {
   }`)
   ).toEqual({
     RegExp: /test/gi,
-    Binary: new bson.Binary('' as any),
+    Binary: new bson.Binary(),
     BinData: new bson.Binary(Buffer.from('dGVzdAo=', 'base64'), 3),
     UUID: new bson.Binary(
       Buffer.from('3d37923dab8e49319e4693df5fd3599e', 'hex'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,7 +2018,7 @@ bson@^1.0.1:
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.6.tgz#fb819be9a60cd677e0853aee4ca712a785d6618a"
   integrity sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==
 
-bson@^4.0.3, bson@^4.6.3:
+bson@^4.0.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/bson/-/bson-4.6.3.tgz#d1a9a0b84b9e84b62390811fc5580f6a8b1d858c"
   integrity sha512-rAqP5hcUVJhXP2MCSNVsf0oM2OGU1So6A9pVRDYayvJ5+hygXHQApf87wd5NlhPM1J9RJnbqxIG/f8QTzRoQ4A==


### PR DESCRIPTION
### Changes
- Add `bson` v6 to peer dependencies

### Breaking Changes
- Set Node minor version to 16 (previously 14)

Fix #186